### PR TITLE
Draft: Introduce optional process pool feature to avoid GIL

### DIFF
--- a/mlonmcu/cli/build.py
+++ b/mlonmcu/cli/build.py
@@ -75,7 +75,7 @@ def _handle(args, context, require_target=False):
     for run in session.runs:
         for target_name in targets:
             for backend_name in backends:
-                new_run = run.copy()
+                new_run = run.copy(session=session)
                 if backend_name is not None:
                     platform_name = None
                     for platform in platforms:

--- a/mlonmcu/cli/common.py
+++ b/mlonmcu/cli/common.py
@@ -22,6 +22,7 @@ import multiprocessing
 import logging
 import argparse
 
+from mlonmcu.config import str2bool
 from mlonmcu.platform import get_platforms
 from mlonmcu.session.postprocess import SUPPORTED_POSTPROCESSES
 from mlonmcu.feature.features import get_available_feature_names
@@ -218,12 +219,13 @@ def kickoff_runs(args, until, context):
     assert len(context.sessions) > 0
     session = context.sessions[-1]
     # session.label = args.label
-    config = extract_config(args)
+    config, config_gen = extract_config(args)
     # TODO: move into context/session
     per_stage = True
     print_report = True
     if "runs_per_stage" in config:
-        per_stage = bool(config["runs_per_stage"])
+        value = config["runs_per_stage"]
+        per_stage = str2bool(value) if isinstance(value, str) else value
     elif "runs_per_stage" in context.environment.vars:
         per_stage = bool(context.environment.vars["runs_per_stage"])
     if "print_report" in config:

--- a/mlonmcu/cli/compile.py
+++ b/mlonmcu/cli/compile.py
@@ -60,7 +60,7 @@ def _handle(args, context):
         else:
             targets_ = [None]
         for target_name in targets_:
-            new_run = run.copy()
+            new_run = run.copy(session=session)
             if target_name is not None:
                 platform_name = None
                 for platform in platforms:

--- a/mlonmcu/cli/compile.py
+++ b/mlonmcu/cli/compile.py
@@ -54,7 +54,7 @@ def _handle(args, context):
     session = context.sessions[-1]
     new_runs = []
     for run in session.runs:
-        if run.target is None:
+        if run.has_target():
             # assert run.compile_platform is None
             targets_ = targets
         else:

--- a/mlonmcu/cli/compile.py
+++ b/mlonmcu/cli/compile.py
@@ -54,7 +54,7 @@ def _handle(args, context):
     session = context.sessions[-1]
     new_runs = []
     for run in session.runs:
-        if run.has_target():
+        if not run.has_target():
             # assert run.compile_platform is None
             targets_ = targets
         else:

--- a/mlonmcu/context/context.py
+++ b/mlonmcu/context/context.py
@@ -566,3 +566,13 @@ class MlonMcuContext:
             logger.debug("Releasing lock on context")
             self.deps_lock.release()
         return False
+
+    def get_read_only_context(self):
+        return MlonMcuContextMinimal(self)
+
+
+class MlonMcuContextMinimal:
+
+    def __init__(self, context: MlonMcuContext):
+        self.environment = context.environment
+        self.cache = context.cache

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -105,22 +105,23 @@ class RunInitializer:
         run = Run(
             idx=self.idx,
             config=self.config,
-            comment=self.comment,
         )
+        if self.comment:
+            run.comment = self.comment
         if self.frontend_names:
             run.add_frontends_by_name(self.frontend_names, context=context)
         if self.model_name:
             run.add_model_by_name(self.model_name, context=context)
         if self.platform_names:
-            run.add_platforms_by_name(self, self.platform_names, context=context)
+            run.add_platforms_by_name(self.platform_names, context=context)
         if self.backend_name:
-            run.add_backend_by_name(self, self.backend_name, context=context)
+            run.add_backend_by_name(self.backend_name, context=context)
         if self.target_name:
-            run.add_target_by_name(self, self.target_name, context=context)
+            run.add_target_by_name(self.target_name, context=context)
         if self.postprocess_names:
-            run.add_postprocesses_by_name(self, self.postprocess_names, context=context)
+            run.add_postprocesses_by_name(self.postprocess_names, context=context)
         if self.feature_names:
-            run.add_features_by_name(self, self.feature_names, context=context)
+            run.add_features_by_name(self.feature_names, context=context)
         return run
 
     def has_target(self):
@@ -182,9 +183,20 @@ class RunInitializer:
 
 
 class RunResult:
+    # def __init__(self, run: "Run", session: "Session"):
     def __init__(self, run: "Run"):
-        self.foo = "bar"
+        self.idx = run.idx
         self.failing = run.failing
+        # self.report = run.get_report(session=session)
+        self.report = run.get_report()
+
+    def get_report(self, session=None):
+        # TODO: read only?!
+        # if session is not None:
+        #     pre = self.report.pre_df
+        #     pre["Session"] = session.idx
+        #     self.report.pre_df = pre
+        return self.report
 
 
 class Run:

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -71,6 +71,122 @@ def add_any(new, base=None, append=True):
     return ret
 
 
+class RunInitializer:
+
+    def __init__(
+        self,
+        idx=None,
+        model_name=None,
+        framework_name=None,
+        frontend_names=None,
+        backend_name=None,
+        target_name=None,
+        platform_names=None,
+        feature_names=None,
+        config=None,
+        postprocess_names=None,
+        comment=None,
+        from_stage=None,
+    ):
+        self.idx = idx
+        self.model_name = model_name
+        self.frontend_names = frontend_names
+        self.framework_name = framework_name
+        self.backend_name = backend_name
+        self.platform_names = platform_names
+        self.postprocess_names = postprocess_names
+        self.comment = comment
+        self.target_name = target_name
+        self.config = config
+        self.feature_names = feature_names
+
+    def realize(self, context=None):
+        assert context is not None
+        run = Run(
+            idx=self.idx,
+            config=self.config,
+            comment=self.comment,
+        )
+        if self.frontend_names:
+            run.add_frontends_by_name(self.frontend_names, context=context)
+        if self.model_name:
+            run.add_model_by_name(self.model_name, context=context)
+        if self.platform_names:
+            run.add_platforms_by_name(self, self.platform_names, context=context)
+        if self.backend_name:
+            run.add_backend_by_name(self, self.backend_name, context=context)
+        if self.target_name:
+            run.add_target_by_name(self, self.target_name, context=context)
+        if self.postprocess_names:
+            run.add_postprocesses_by_name(self, self.postprocess_names, context=context)
+        if self.feature_names:
+            run.add_features_by_name(self, self.feature_names, context=context)
+        return run
+
+    def has_target(self):
+        return self.target_name is not None
+
+    def add_model_by_name(self, model_name, context=None):
+        assert self.model_name is None
+        self.model_name = model_name
+
+    def add_frontend_by_name(self, frontend_name, context=None):
+        self.add_frontends_by_name([frontend_name])
+
+    def add_frontends_by_name(self, frontend_names, context=None):
+        if self.frontend_names is None:
+            self.frontend_names = []
+        self.frontend_names.extend(frontend_names)
+
+    def add_backend_by_name(self, backend_name, context=None):
+        assert self.backend_name is None
+        self.backend_name = backend_name
+
+    def add_target_by_name(self, target_name, context=None):
+        # assert self.target_name is None
+        self.target_name = target_name
+
+    def add_platform_by_name(self, platform_name, context=None):
+        self.add_platforms_by_name([platform_name])
+
+    def add_platforms_by_name(self, platform_names, context=None):
+        if self.platform_names is None:
+            self.platform_names = []
+        self.platform_names.extend(platform_names)
+
+    def add_postprocess_by_name(self, postprocess_name, context=None):
+        self.add_postprocesses_by_name([postprocess_name])
+
+    def add_postprocesses_by_name(self, postprocess_names, context=None):
+        if self.postprocess_names is None:
+            self.postprocess_names = []
+        self.postprocess_names.extend(postprocess_names)
+
+    def add_feature_by_name(self, feature_name, context=None):
+        self.add_features_by_name([feature_name])
+
+    def add_features_by_name(self, feature_names, context=None):
+        if self.feature_names is None:
+            self.feature_names = []
+        self.feature_names.extend(feature_names)
+
+    def copy(self, session=None):
+        """Create a new runinitializer based on this instance."""
+        new = copy.deepcopy(self)
+        assert session is not None, "Run.copy() needs session"
+        if session:
+            new_idx = session.request_run_idx()
+            new.idx = new_idx
+            # self.init_directory()
+        return new
+
+
+class RunResult:
+    def __init__(self, run: "Run"):
+        self.foo = "bar"
+        self.failing = run.failing
+
+
 class Run:
     """A run is single model/backend/framework/target combination with a given set of features and configs."""
 

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -259,7 +259,7 @@ class Run:
         self.run_config = filter_config(self.config, "run", self.DEFAULTS, self.OPTIONAL, self.REQUIRED)
         self.sub_names = []
         self.sub_parents = {}
-        self.result = None
+        # self.result = None
         self.failing = False  # -> RunStatus
         self.reason = None
         self.failed_stage = None

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -268,6 +268,9 @@ class Run:
             self.run_config = filter_config(tmp_run_config, "run", self.DEFAULTS, self.OPTIONAL, self.REQUIRED)
         return features
 
+    def has_target(self):
+        return self.target is not None
+
     @property
     def tune_enabled(self):
         """Get tune_enabled property."""

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -108,6 +108,8 @@ class RunInitializer:
         )
         if self.comment:
             run.comment = self.comment
+        if self.feature_names:
+            run.add_features_by_name(self.feature_names, context=context)
         if self.frontend_names:
             run.add_frontends_by_name(self.frontend_names, context=context)
         if self.model_name:
@@ -120,8 +122,6 @@ class RunInitializer:
             run.add_target_by_name(self.target_name, context=context)
         if self.postprocess_names:
             run.add_postprocesses_by_name(self.postprocess_names, context=context)
-        if self.feature_names:
-            run.add_features_by_name(self.feature_names, context=context)
         return run
 
     def has_target(self):
@@ -427,22 +427,22 @@ class Run:
             self.dir = session.runs_dir / str(self.idx)
             if not self.dir.is_dir():
                 os.mkdir(self.dir)
-            # This is not a good idea, but else we would need a mutex/lock on the shared build_dir
-            # A solution would be to split up the framework runtime libs from the mlif...
-            for platform in self.platforms:  # TODO: only do this if needed! (not for every platform)
-                # The stage_subdirs setting is ignored here because platforms can be multi-stage!
-                # platform.init_directory(path=Path(self.dir) / platform.name)
-                if platform in self.directories:
-                    continue
-                platform_dir = Path(self.dir) / platform.name
-                if platform.init_directory(path=platform_dir):
-                    self.directories[platform.name] = platform_dir
-            # if target not in self.directories:
-            #     target_dir = Path(self.dir) /target.name
-            #     if target.init_directory(path=target_dir)
-            #         self.directories[target.name] = target_dir
+        # This is not a good idea, but else we would need a mutex/lock on the shared build_dir
+        # A solution would be to split up the framework runtime libs from the mlif...
+        for platform in self.platforms:  # TODO: only do this if needed! (not for every platform)
+            # The stage_subdirs setting is ignored here because platforms can be multi-stage!
+            # platform.init_directory(path=Path(self.dir) / platform.name)
+            if platform in self.directories:
+                continue
+            platform_dir = Path(self.dir) / platform.name
+            if platform.init_directory(path=platform_dir):
+                self.directories[platform.name] = platform_dir
+        # if target not in self.directories:
+        #     target_dir = Path(self.dir) /target.name
+        #     if target.init_directory(path=target_dir)
+        #         self.directories[target.name] = target_dir
 
-            # TODO: other components
+        # TODO: other components
 
     def __deepcopy__(self, memo):
         cls = self.__class__

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -266,6 +266,7 @@ class Run:
         # self.lock = threading.Lock()  # FIXME: use mutex instead of boolean
         self.locked = False
         self.report = None
+        self.dir = None
 
     def process_features(self, features):
         """Utility which handles postprocess_features."""

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -420,8 +420,11 @@ class Run:
         """Initialize the temporary directory for this run."""
         if session is None:
             assert not self.archived
-            self.tempdir = tempfile.TemporaryDirectory()
-            self.dir = Path(self.tempdir.name)
+            # self.tempdir = tempfile.TemporaryDirectory()
+            # self.dir = Path(self.tempdir.name)
+            self.dir = Path("/tmp") / str(self.idx)
+            if not self.dir.is_dir():
+                os.mkdir(self.dir)
         else:
             self.tempdir = None
             self.dir = session.runs_dir / str(self.idx)

--- a/mlonmcu/session/run.py
+++ b/mlonmcu/session/run.py
@@ -1421,5 +1421,8 @@ class Run:
 
         self.write_run_file()
 
+    def result(self):
+        return RunResult(self)  # TODO: session?
+
 
 # TODO: implement close()? and use closing contextlib?

--- a/mlonmcu/target/riscv/etiss.py
+++ b/mlonmcu/target/riscv/etiss.py
@@ -527,71 +527,73 @@ class EtissTarget(RISCVTarget):
         metrics = Metrics()
         self.parse_stdout(out, metrics, exit_code=exit_code)
 
-        get_metrics_args = [elf]
         etiss_ini = os.path.join(directory, "custom.ini")
-        if os.path.exists(etiss_ini):
-            get_metrics_args.extend(["--ini", etiss_ini])
-        if trace_file:
-            get_metrics_args.extend(["--trace", trace_file])
-        get_metrics_args.extend(["--out", metrics_file])
-        if self.print_outputs:
-            out += execute(self.metrics_script.resolve(), *get_metrics_args, live=True)
-        else:
-            out += execute(
-                self.metrics_script.resolve(),
-                *get_metrics_args,
-                live=False,
-                cwd=directory,
-                print_func=lambda *args, **kwargs: None,
-            )
+        needs_get_metrics = self.trace_memory
+        if needs_get_metrics:
+            get_metrics_args = [elf]
+            if os.path.exists(etiss_ini):
+                get_metrics_args.extend(["--ini", etiss_ini])
+            if trace_file:
+                get_metrics_args.extend(["--trace", trace_file])
+            get_metrics_args.extend(["--out", metrics_file])
+            if self.print_outputs:
+                out += execute(self.metrics_script.resolve(), *get_metrics_args, live=True)
+            else:
+                out += execute(
+                    self.metrics_script.resolve(),
+                    *get_metrics_args,
+                    live=False,
+                    cwd=directory,
+                    print_func=lambda *args, **kwargs: None,
+                )
 
-        metrics_file = os.path.join(directory, "metrics.csv")
-        with open(metrics_file, "r") as handle:
-            metrics_content = handle.read()
-            lines = metrics_content.splitlines()
-            reader = csv.DictReader(lines)
-            data = list(reader)[0]
+            metrics_file = os.path.join(directory, "metrics.csv")
+            with open(metrics_file, "r") as handle:
+                metrics_content = handle.read()
+                lines = metrics_content.splitlines()
+                reader = csv.DictReader(lines)
+                data = list(reader)[0]
 
-            def get_rom_sizes(data):
-                assert "rom_rodata" in data
-                rom_ro = int(data["rom_rodata"])
-                assert "rom_code" in data
-                rom_code = int(data["rom_code"])
-                assert "rom_misc" in data
-                rom_misc = int(data["rom_misc"])
+                # def get_rom_sizes(data):
+                #     assert "rom_rodata" in data
+                #     rom_ro = int(data["rom_rodata"])
+                #     assert "rom_code" in data
+                #     rom_code = int(data["rom_code"])
+                #     assert "rom_misc" in data
+                #     rom_misc = int(data["rom_misc"])
 
-                rom_total = rom_ro + rom_code + rom_misc
-                return rom_total, rom_ro, rom_code, rom_misc
+                #     rom_total = rom_ro + rom_code + rom_misc
+                #     return rom_total, rom_ro, rom_code, rom_misc
 
-            def get_ram_sizes(data):
-                assert "ram_data" in data
-                ram_data = int(data["ram_data"])
-                assert "ram_zdata" in data
-                ram_zdata = int(data["ram_zdata"])
-                ram_total = ram_data + ram_zdata
+                def get_ram_sizes(data):
+                    assert "ram_data" in data
+                    ram_data = int(data["ram_data"])
+                    assert "ram_zdata" in data
+                    ram_zdata = int(data["ram_zdata"])
+                    ram_total = ram_data + ram_zdata
+                    if self.trace_memory:
+                        assert "ram_stack" in data
+                        ram_stack = int(data["ram_stack"])
+                        assert "ram_heap" in data
+                        ram_heap = int(data["ram_heap"])
+                        ram_total += ram_stack + ram_heap
+                    else:
+                        ram_stack = None
+                        ram_heap = None
+                    return ram_total, ram_data, ram_zdata, ram_stack, ram_heap
+
+                # rom_total, rom_ro, rom_code, rom_misc = get_rom_sizes(data)
+                ram_total, ram_data, ram_zdata, ram_stack, ram_heap = get_ram_sizes(data)
+                # metrics.add("Total ROM", rom_total)
+                metrics.add("Total RAM", ram_total)
+                # metrics.add("ROM read-only", rom_ro)
+                # metrics.add("ROM code", rom_code)
+                # metrics.add("ROM misc", rom_misc)
+                metrics.add("RAM data", ram_data)
+                metrics.add("RAM zero-init data", ram_zdata)
                 if self.trace_memory:
-                    assert "ram_stack" in data
-                    ram_stack = int(data["ram_stack"])
-                    assert "ram_heap" in data
-                    ram_heap = int(data["ram_heap"])
-                    ram_total += ram_stack + ram_heap
-                else:
-                    ram_stack = None
-                    ram_heap = None
-                return ram_total, ram_data, ram_zdata, ram_stack, ram_heap
-
-            rom_total, rom_ro, rom_code, rom_misc = get_rom_sizes(data)
-            ram_total, ram_data, ram_zdata, ram_stack, ram_heap = get_ram_sizes(data)
-            metrics.add("Total ROM", rom_total)
-            metrics.add("Total RAM", ram_total)
-            metrics.add("ROM read-only", rom_ro)
-            metrics.add("ROM code", rom_code)
-            metrics.add("ROM misc", rom_misc)
-            metrics.add("RAM data", ram_data)
-            metrics.add("RAM zero-init data", ram_zdata)
-            if self.trace_memory:
-                metrics.add("RAM stack", ram_stack)
-                metrics.add("RAM heap", ram_heap)
+                    metrics.add("RAM stack", ram_stack)
+                    metrics.add("RAM heap", ram_heap)
 
         artifacts = []
         ini_content = open(etiss_ini, "r").read()


### PR DESCRIPTION
See #153 for more context

**Summary of changes:**
- Drop `Run.session` in favor of passing the session as argument when needed (Session class can not be serialized)
- Fix: broken detection of global config passed via cmdline (TODO: cherry-pick to develop)
- Add `Run.has_target()`helper
- Introduce `MlonMcuContextMinimal` to pass environment settings and cache to processes (Locks can not be serialized)

**Limitations:**
- `runs_per_stage` feature does not work together with `process_pool`
- No support for progress bars (`--progress`)
- `Run.prefix` property is missing session idx
- Run dir is created in `/tmp` instead of session dir

**TODOs:**
- [ ] Cleanups/Linting
- [ ] Documentation
- [ ] Testing
- [ ] Restore progress bar support
- [ ] Use RunInitializer and RunResult by default
- [ ] Refactor MLonMCUContextMinimal
- [ ] Expose session IDX and session dir to runs which out sharing session class
- [ ] Drop `Run.__deepcopy__` as not needed anymore