### PR TITLE
Feature Backend onnx2c

### DIFF
--- a/mlonmcu/flow/__init__.py
+++ b/mlonmcu/flow/__init__.py
@@ -39,6 +39,7 @@ from mlonmcu.flow.iree.backend.ireellvm import IREELLVMBackend
 from mlonmcu.flow.iree.backend.ireellvm_inline import IREELLVMInlineBackend
 from mlonmcu.flow.iree.backend.ireellvmc import IREELLVMCBackend
 from mlonmcu.flow.iree.backend.ireellvmc_inline import IREELLVMCInlineBackend
+from mlonmcu.flow.onnx.backend.onnx2c import Onnx2CBackend
 
 # from mlonmcu.flow.none.backend.none import NoneBackend
 from .framework import Framework
@@ -122,6 +123,7 @@ SUPPORTED_IREE_BACKENDS = {
 
 SUPPORTED_NONE_BACKENDS = {
     "none": NoneBackend,
+    "onnx2c": Onnx2CBackend,
 }
 
 SUPPORTED_FRAMEWORK_BACKENDS = {

--- a/mlonmcu/flow/onnx/__init__.py
+++ b/mlonmcu/flow/onnx/__init__.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2022 TUM Department of Electrical and Computer Engineering.
+#
+# This file is part of MLonMCU.
+# See https://github.com/tum-ei-eda/mlonmcu.git for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .backend import ONNXBackend, Onnx2CBackend
+
+__all__ = ["ONNXBackend", "Onnx2CBackend"]

--- a/mlonmcu/flow/onnx/backend/__init__.py
+++ b/mlonmcu/flow/onnx/backend/__init__.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 TUM Department of Electrical and Computer Engineering.
+#
+# This file is part of MLonMCU.
+# See https://github.com/tum-ei-eda/mlonmcu.git for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .backend import ONNXBackend
+from .onnx2c import Onnx2CBackend
+
+__all__ = ["ONNXBackend", "Onnx2CBackend"]

--- a/mlonmcu/flow/onnx/backend/backend.py
+++ b/mlonmcu/flow/onnx/backend/backend.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2022 TUM Department of Electrical and Computer Engineering.
+#
+# This file is part of MLonMCU.
+# See https://github.com/tum-ei-eda/mlonmcu.git for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+
+from mlonmcu.flow.backend import Backend
+from mlonmcu.models.model import ModelFormats
+
+
+class ONNXBackend(Backend):
+    registry = {}
+
+    name = None
+
+    FEATURES = set()
+
+    DEFAULTS = {}
+
+    REQUIRED = set()
+
+    def __init__(self, features=None, config=None):
+        super().__init__(framework="none", config=config, features=features)
+        self.model = None
+        self.supported_formats = [ModelFormats.ONNX]
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        assert isinstance(cls.name, str)
+        cls.registry[cls.name] = cls
+
+    def load_model(
+        self, model, input_shapes=None, output_shapes=None, input_types=None, output_types=None, params_path=None
+    ):
+        assert input_shapes is None
+        assert output_shapes is None
+        assert input_types is None
+        assert output_types is None
+        assert params_path is None
+        self.model = model
+        ext = os.path.splitext(model)[1][1:]
+        fmt = ModelFormats.from_extension(ext)
+        assert fmt == ModelFormats.ONNX, f"Backend '{self.name}' does not support model format: {fmt.name}"

--- a/mlonmcu/flow/onnx/backend/onnx2c.py
+++ b/mlonmcu/flow/onnx/backend/onnx2c.py
@@ -252,8 +252,59 @@ class Onnx2CBackend(ONNXBackend):
             for output_name in node.output:
                 producer_by_output[output_name] = node
 
+        matmulinteger_a_zero_points = set()
+        matmulinteger_b_zero_points = set()
+        for node in model.graph.node:
+            if node.op_type == "MatMulInteger" and len(node.input) >= 3:
+                matmulinteger_a_zero_points.add(node.input[2])
+            if node.op_type == "MatMulInteger" and len(node.input) >= 4:
+                matmulinteger_b_zero_points.add(node.input[3])
+
+        def collapse_uniform_zero_point(name):
+            init = initializer_map.get(name)
+            if init is None:
+                return False
+            arr = numpy_helper.to_array(init)
+            if arr.size == 0:
+                return False
+            flat = arr.reshape(-1)
+            if not np.all(flat == flat[0]):
+                logger.warning(
+                    "Collapsing non-uniform MatMulInteger zero-point '%s' to scalar for onnx2c compatibility",
+                    name,
+                )
+            scalar_value = np.array([flat[0]], dtype=arr.dtype)
+            upsert_initializer(numpy_helper.from_array(scalar_value, name=name))
+            return True
+
+        for name in sorted(matmulinteger_b_zero_points):
+            if collapse_uniform_zero_point(name):
+                changed = True
+
+        zp_redirects = {}
         rewritten_nodes = []
         for idx, node in enumerate(model.graph.node):
+            for input_index, input_name in enumerate(node.input):
+                if input_name in zp_redirects:
+                    node.input[input_index] = zp_redirects[input_name]
+
+            if node.op_type == "DynamicQuantizeLinear" and len(node.output) >= 3 and node.output[2] in matmulinteger_a_zero_points:
+                zp_shape_name = f"{node.name or ('dql_' + str(idx))}_zero_point_shape"
+                zp_output_name = f"{node.output[2]}_rank1"
+                model.graph.initializer.append(helper.make_tensor(zp_shape_name, TensorProto.INT64, [1], [1]))
+                rewritten_nodes.append(node)
+                rewritten_nodes.append(
+                    helper.make_node(
+                        "Reshape",
+                        [node.output[2], zp_shape_name],
+                        [zp_output_name],
+                        name=f"{node.name}_zero_point_fix",
+                    )
+                )
+                zp_redirects[node.output[2]] = zp_output_name
+                changed = True
+                continue
+
             if node.op_type not in ops or len(node.input) < 2:
                 rewritten_nodes.append(node)
                 continue

--- a/mlonmcu/flow/onnx/backend/onnx2c.py
+++ b/mlonmcu/flow/onnx/backend/onnx2c.py
@@ -1,0 +1,516 @@
+#
+# Copyright (c) 2022 TUM Department of Electrical and Computer Engineering.
+#
+# This file is part of MLonMCU.
+# See https://github.com/tum-ei-eda/mlonmcu.git for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+import mlonmcu.setup.utils as utils
+from mlonmcu.artifact import Artifact, ArtifactFormat
+from mlonmcu.config import str2bool, str2dict
+from mlonmcu.flow.backend import main
+from mlonmcu.logging import get_logger
+
+from .backend import ONNXBackend
+
+logger = get_logger()
+
+
+class Onnx2CBackend(ONNXBackend):
+    name = "onnx2c"
+
+    FEATURES = set()
+
+    DEFAULTS = {
+        "print_outputs": False,
+        "log_level": 0,
+        "func_name": "entry",
+        "no_globals": False,
+        "extern_init": False,
+        "only_init": False,
+        "avr": False,
+        "optimizations": None,
+        "define": {},
+        "sanitize_legacy_broadcast_attrs": True,
+        "sanitized_model_out": None,
+    }
+
+    REQUIRED = ONNXBackend.REQUIRED | {"onnx2c.exe"}
+
+    @property
+    def print_outputs(self):
+        return str2bool(self.config["print_outputs"])
+
+    @property
+    def log_level(self):
+        return int(self.config["log_level"])
+
+    @property
+    def func_name(self):
+        return self.config["func_name"]
+
+    @property
+    def no_globals(self):
+        return str2bool(self.config["no_globals"])
+
+    @property
+    def extern_init(self):
+        return str2bool(self.config["extern_init"])
+
+    @property
+    def only_init(self):
+        return str2bool(self.config["only_init"])
+
+    @property
+    def avr(self):
+        return str2bool(self.config["avr"])
+
+    @property
+    def optimizations(self):
+        return self.config["optimizations"]
+
+    @property
+    def define(self):
+        value = self.config["define"]
+        if isinstance(value, str):
+            value = str2dict(value)
+        assert isinstance(value, dict)
+        return value
+
+    @property
+    def sanitize_legacy_broadcast_attrs(self):
+        return str2bool(self.config["sanitize_legacy_broadcast_attrs"])
+
+    @property
+    def sanitized_model_out(self):
+        return self.config["sanitized_model_out"]
+
+    def _sanitize_model_for_onnx2c(self, model_path, out_path):
+        if not self.sanitize_legacy_broadcast_attrs:
+            return model_path
+        try:
+            import numpy as np
+            import onnx
+            from onnx import TensorProto, helper, numpy_helper
+        except ImportError:
+            logger.warning("ONNX package not available, skipping attribute sanitization for onnx2c")
+            return model_path
+
+        model = onnx.load(str(model_path))
+        changed = False
+        legacy_axis = {}
+
+        initializer_map = {init.name: init for init in model.graph.initializer}
+
+        def upsert_initializer(new_init):
+            for i in range(len(model.graph.initializer) - 1, -1, -1):
+                if model.graph.initializer[i].name == new_init.name:
+                    del model.graph.initializer[i]
+            model.graph.initializer.append(new_init)
+            initializer_map[new_init.name] = new_init
+
+        def get_shape_map():
+            ret = {}
+            for vi in list(model.graph.input) + list(model.graph.value_info) + list(model.graph.output):
+                tt = vi.type.tensor_type
+                if not tt.HasField("shape"):
+                    continue
+                dims = []
+                valid = True
+                for dim in tt.shape.dim:
+                    if dim.HasField("dim_value"):
+                        dims.append(int(dim.dim_value))
+                    else:
+                        valid = False
+                        break
+                if valid:
+                    ret[vi.name] = dims
+            for init in model.graph.initializer:
+                ret[init.name] = list(init.dims)
+            return ret
+
+        attr_names = {"axis", "broadcast"}
+        ops = {"Add", "Sub", "Mul", "Div", "Sum", "Max", "Min", "Mean"}
+
+        for node in model.graph.node:
+            if node.op_type not in ops:
+                continue
+            axis_attr = next((attr for attr in node.attribute if attr.name == "axis"), None)
+            if axis_attr is not None and node.name:
+                legacy_axis[node.name] = int(axis_attr.i)
+            keep = [attr for attr in node.attribute if attr.name not in attr_names]
+            if len(keep) != len(node.attribute):
+                del node.attribute[:]
+                node.attribute.extend(keep)
+                changed = True
+
+        nodes_to_drop = set()
+        for idx, node in enumerate(model.graph.node):
+            if node.op_type != "Reshape":
+                continue
+            shape_attr = None
+            keep = []
+            for attr in node.attribute:
+                if attr.name == "shape":
+                    shape_attr = attr
+                else:
+                    keep.append(attr)
+            if shape_attr is None:
+                continue
+
+            if len(node.input) >= 1 and node.input[0] in initializer_map:
+                shape_vals = list(shape_attr.ints)
+                if shape_vals:
+                    src_arr = numpy_helper.to_array(initializer_map[node.input[0]])
+                    reshaped = np.reshape(src_arr, shape_vals)
+                    upsert_initializer(numpy_helper.from_array(reshaped, name=node.output[0]))
+                    nodes_to_drop.add(node.name if node.name else f"__idx_{idx}")
+                    changed = True
+                    continue
+
+            if len(node.input) >= 2:
+                del node.attribute[:]
+                node.attribute.extend(keep)
+                changed = True
+                continue
+
+            shape_vals = list(shape_attr.ints)
+            if not shape_vals:
+                logger.warning("Reshape node has empty legacy shape attribute: %s", node.name)
+                continue
+            shape_name = f"{node.name or ('reshape_' + str(idx))}_shape"
+            upsert_initializer(helper.make_tensor(shape_name, TensorProto.INT64, [len(shape_vals)], shape_vals))
+            node.input.append(shape_name)
+            del node.attribute[:]
+            node.attribute.extend(keep)
+            changed = True
+
+        if nodes_to_drop:
+            new_nodes = []
+            for idx, node in enumerate(model.graph.node):
+                key = node.name if node.name else f"__idx_{idx}"
+                if key not in nodes_to_drop:
+                    new_nodes.append(node)
+            del model.graph.node[:]
+            model.graph.node.extend(new_nodes)
+
+        shape_map = get_shape_map()
+        consumers = {}
+        for node in model.graph.node:
+            for inp in node.input:
+                consumers.setdefault(inp, []).append(node)
+
+        for node in model.graph.node:
+            if node.op_type != "Reshape" or len(node.input) < 2 or len(node.output) == 0:
+                continue
+            if not node.name.endswith("_reshape1"):
+                continue
+            shape_init_name = node.input[1]
+            if shape_init_name not in initializer_map:
+                continue
+            shape_vals = numpy_helper.to_array(initializer_map[shape_init_name]).tolist()
+            if not isinstance(shape_vals, list) or len(shape_vals) != 1:
+                continue
+            channel = int(shape_vals[0])
+            if channel <= 0:
+                continue
+            for cons in consumers.get(node.output[0], []):
+                if cons.op_type not in ops or len(cons.input) < 2:
+                    continue
+                if cons.op_type == "Add" and cons.name.startswith("Plus"):
+                    upsert_initializer(numpy_helper.from_array(np.array([1, channel, 1, 1], dtype=np.int64), name=shape_init_name))
+                    changed = True
+                    break
+                other = cons.input[0] if cons.input[1] == node.output[0] else cons.input[1]
+                other_shape = shape_map.get(other)
+                if other_shape is not None and len(other_shape) == 4:
+                    upsert_initializer(numpy_helper.from_array(np.array([1, channel, 1, 1], dtype=np.int64), name=shape_init_name))
+                    changed = True
+                    break
+
+        shape_map = get_shape_map()
+        producer_by_output = {}
+        for node in model.graph.node:
+            for output_name in node.output:
+                producer_by_output[output_name] = node
+
+        rewritten_nodes = []
+        for idx, node in enumerate(model.graph.node):
+            if node.op_type not in ops or len(node.input) < 2:
+                rewritten_nodes.append(node)
+                continue
+
+            axis_attr = None
+            keep = []
+            for attr in node.attribute:
+                if attr.name == "axis":
+                    axis_attr = int(attr.i)
+                elif attr.name == "broadcast":
+                    continue
+                else:
+                    keep.append(attr)
+            if axis_attr is None and node.name in legacy_axis:
+                axis_attr = legacy_axis[node.name]
+            if axis_attr is None:
+                rewritten_nodes.append(node)
+                continue
+
+            lhs_shape = shape_map.get(node.input[0])
+            rhs_shape = shape_map.get(node.input[1])
+            if rhs_shape is None:
+                prod = producer_by_output.get(node.input[1])
+                if prod is not None and prod.op_type == "Reshape":
+                    shape_attr = next((a for a in prod.attribute if a.name == "shape"), None)
+                    if shape_attr is not None and len(shape_attr.ints) > 0:
+                        rhs_shape = list(shape_attr.ints)
+                    elif len(prod.input) >= 2 and prod.input[1] in initializer_map:
+                        try:
+                            shape_vals = numpy_helper.to_array(initializer_map[prod.input[1]]).tolist()
+                            rhs_shape = [int(x) for x in shape_vals]
+                        except Exception:
+                            rhs_shape = None
+
+            if rhs_shape is None:
+                rewritten_nodes.append(node)
+                continue
+
+            if lhs_shape is None:
+                if axis_attr == 1 and len(rhs_shape) == 1:
+                    lhs_shape = [1, int(rhs_shape[0]), 1, 1]
+                else:
+                    rewritten_nodes.append(node)
+                    continue
+
+            lhs_rank = len(lhs_shape)
+            rhs_rank = len(rhs_shape)
+            if axis_attr < 0:
+                axis_attr += lhs_rank
+            if rhs_rank > lhs_rank or axis_attr < 0 or axis_attr + rhs_rank > lhs_rank:
+                rewritten_nodes.append(node)
+                continue
+
+            target_shape = [1] * lhs_rank
+            target_shape[axis_attr : axis_attr + rhs_rank] = list(rhs_shape)
+
+            reshape_out = f"{node.input[1]}_axisfix"
+            shape_name = f"{node.name or ('node_' + str(idx))}_axis_shape"
+            model.graph.initializer.append(helper.make_tensor(shape_name, TensorProto.INT64, [len(target_shape)], target_shape))
+            rewritten_nodes.append(
+                helper.make_node("Reshape", [node.input[1], shape_name], [reshape_out], name=f"{node.name}_axisfix")
+            )
+            node.input[1] = reshape_out
+            del node.attribute[:]
+            node.attribute.extend(keep)
+            rewritten_nodes.append(node)
+            changed = True
+
+        del model.graph.node[:]
+        model.graph.node.extend(rewritten_nodes)
+
+        if not changed:
+            return model_path
+
+        onnx.save(model, str(out_path))
+        logger.info("Sanitized legacy ONNX broadcast attributes for onnx2c: %s", out_path)
+        return out_path
+
+    def _parse_function_signature(self, source_text, func_name):
+        match = re.search(rf"void\s+{re.escape(func_name)}\s*\((.*?)\)\s*\{{", source_text, re.DOTALL)
+        if not match:
+            raise RuntimeError(f"Unable to locate onnx2c function signature: {func_name}(...) in generated source")
+        signature = match.group(1).strip()
+        if not signature:
+            return []
+
+        args = []
+        current = []
+        depth = 0
+        for char in signature:
+            if char == "," and depth == 0:
+                arg = "".join(current).strip()
+                if arg:
+                    args.append(arg)
+                current = []
+                continue
+            if char == "[":
+                depth += 1
+            elif char == "]":
+                depth -= 1
+            current.append(char)
+        final_arg = "".join(current).strip()
+        if final_arg:
+            args.append(final_arg)
+        return args
+
+    def _build_runtime_shim(self, source_text):
+        args = self._parse_function_signature(source_text, self.func_name)
+        input_args = []
+        output_args = []
+        arg_decls = []
+
+        for index, arg in enumerate(args):
+            match = re.match(r"^(?P<type>.+?)\s+(?P<name>[A-Za-z_]\w*)(?P<dims>(?:\[[^\]]+\])*)\s*$", arg)
+            if not match:
+                raise RuntimeError(f"Unable to parse onnx2c function argument: {arg}")
+            arg_type = match.group("type").replace("const ", "")
+            arg_name = match.group("name")
+            arg_dims = match.group("dims")
+            if not arg_dims:
+                raise RuntimeError(f"onnx2c function argument has no array dimensions: {arg}")
+            arg_decls.append(f"static {arg_type} {arg_name}{arg_dims};")
+            if index == 0:
+                input_args.append((arg_name, f"sizeof({arg_name})"))
+            else:
+                output_args.append((arg_name, f"sizeof({arg_name})"))
+
+        if not input_args:
+            raise RuntimeError("onnx2c runtime shim needs at least one model input")
+        if not output_args:
+            raise RuntimeError("onnx2c runtime shim needs at least one model output")
+
+        call_args = ", ".join([name for name, _ in input_args + output_args])
+        input_calls = "\n    ".join([f"ret = mlif_request_input({name}, {size}, &new_);" for name, size in input_args])
+        output_calls = "\n              ".join([f"ret = mlif_handle_result({name}, {size});" for name, size in output_args])
+
+        return f"""#include "ml_interface.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+{chr(10).join(arg_decls)}
+
+extern void {self.func_name}({', '.join(args)});
+
+int mlonmcu_init() {{
+  return 0;
+}}
+
+int mlonmcu_deinit() {{
+  return 0;
+}}
+
+int mlonmcu_run() {{
+  size_t remaining = NUM_RUNS;
+  while (remaining) {{
+    {self.func_name}({call_args});
+    remaining--;
+  }}
+  return 0;
+}}
+
+int mlonmcu_check() {{
+  size_t input_num = 0;
+  int ret = 0;
+  bool new_ = false;
+  while (true) {{
+    {input_calls}
+    if (ret) {{
+      return ret;
+    }}
+    if (!new_) {{
+      break;
+    }}
+    if (input_num == {len(input_args) - 1}) {{
+      {self.func_name}({call_args});
+      {output_calls}
+      if (ret) {{
+        return ret;
+      }}
+      input_num = 0;
+    }} else {{
+      input_num++;
+    }}
+  }}
+  return ret;
+}}
+"""
+
+    def generate(self) -> Tuple[dict, dict]:
+        assert self.model is not None
+        artifacts = []
+        onnx2c_exe = self.config["onnx2c.exe"]
+
+        base_name = Path(self.model).stem
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model_path = Path(self.model)
+            sanitized_path = Path(tmpdirname) / f"{base_name}.sanitized.onnx"
+            model_to_use = self._sanitize_model_for_onnx2c(model_path, sanitized_path)
+
+            args = []
+            if self.avr:
+                args.append("--avr")
+            if self.no_globals:
+                args.append("--no-globals")
+            if self.extern_init:
+                args.append("--extern-init")
+            if self.only_init:
+                args.append("--only-init")
+
+            args.extend(["--log", str(self.log_level)])
+            args.extend(["--func-name", self.func_name])
+
+            if self.optimizations:
+                args.extend(["--optimizations", str(self.optimizations)])
+
+            for dim, size in self.define.items():
+                args.extend(["--define", f"{dim}:{size}"])
+
+            args.append(str(model_to_use))
+
+            out = utils.execute(onnx2c_exe, *args, live=self.print_outputs)
+            source_artifact = Artifact(f"{base_name}.c", content=out, fmt=ArtifactFormat.SOURCE)
+            artifacts.append(source_artifact)
+
+            shim_content = self._build_runtime_shim(out)
+            shim_artifact = Artifact(f"{base_name}_mlif.c", content=shim_content, fmt=ArtifactFormat.SOURCE)
+            artifacts.append(shim_artifact)
+
+            if model_to_use != model_path:
+                with open(model_to_use, "rb") as in_file:
+                    sanitized_data = in_file.read()
+                out_path = self.sanitized_model_out
+                if out_path:
+                    out_path = Path(out_path)
+                    if not out_path.is_absolute():
+                        out_path = Path(os.getcwd()) / out_path
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    out_path.write_bytes(sanitized_data)
+                artifacts.append(
+                    Artifact(
+                        f"{base_name}.sanitized.onnx",
+                        raw=sanitized_data,
+                        fmt=ArtifactFormat.RAW,
+                    )
+                )
+
+            artifacts.append(Artifact("onnx2c_out.log", content=out, fmt=ArtifactFormat.TEXT))
+
+        return {"default": artifacts}, {}
+
+
+if __name__ == "__main__":
+    sys.exit(
+        main(
+            Onnx2CBackend,
+            args=sys.argv[1:],
+        )
+    )  # pragma: no cover

--- a/mlonmcu/resources/templates/onnx2c.yml.j2
+++ b/mlonmcu/resources/templates/onnx2c.yml.j2
@@ -1,0 +1,255 @@
+---
+# The MLONMCU_HOME is filled in automatically when creating the environment
+home: "{{ home_dir }}"
+logging:
+  level: DEBUG
+  to_file: false
+  rotate: false
+cleanup:
+  auto: true
+  keep: 50
+# Default locations for certain directoriescan be changed here
+# Non-absolute paths will always be threated relative to the MLONMCU_HOME
+paths:
+  # Where the dependencies are downloaded and installed
+  deps: deps
+  # If logging to file is used keep logs in this directory
+  logs: logs
+  # Location where reports and artifacts are written to
+  results: results
+  # Directory where custom extensions can be integrated
+  plugins: plugins
+  # Directory for intermediate build products, should be located on a large enough drive
+  temp: temp
+  # A collection of models which will be used to look for models
+  # The paths will be checked in the order defined here stopping at the first match
+  # Non-existant paths will be skipped without throwing an error
+  models:
+    - "{{ home_dir }}/models"
+    - "{{ config_dir }}/models"
+# Here default clone_urls
+repos:
+  tensorflow:
+    url: "https://github.com/tensorflow/tflite-micro.git"
+    ref: ca5358f4680dbd94717a4c6bd77186bc1c799e1b
+  tflite_micro_compiler:
+    url: "https://github.com/PhilippvK/tflite_micro_compiler.git"
+    ref: 0e4b533a7a9e8ad30cf81fd24c77d12639431615
+  tvm:
+    url: "https://github.com/apache/tvm.git"
+    ref: 76b9ce9b1f7d2b7e64b4b9c9d456a02b8a010473
+    options:
+      recursive: true
+  utvm_staticrt_codegen:
+    url: "https://github.com/tum-ei-eda/utvm_staticrt_codegen.git"
+    ref: 1b296f1efcc28671ee21ccbe86a81b968db8b1e5
+  tvm_extensions:
+    url: "https://github.com/tum-ei-eda/tvm_extensions.git"
+    ref: 3ccd1ad8e4eed0cd86bfbd866d066833fd174dcb
+  muriscvnn:
+    url: "https://github.com/tum-ei-eda/muriscv-nn.git"
+    ref: 04bda19e1d2a829d35394c630878d578eac27b0b
+  etiss:
+    url: "https://github.com/tum-ei-eda/etiss.git"
+    ref: 78716e7f8e9ee0be0b15d41815d75b35fa2ecaa5
+  spike:
+    url: "https://github.com/riscv-software-src/riscv-isa-sim.git"
+    ref: caf5a420ef7414031368739e16d60f3f418aa6ac
+  spikepk:
+    url: "https://github.com/riscv-software-src/riscv-pk.git"
+    ref: 2efabd3e6604b8a9e8f70baf52f57696680c7855
+  cmsis:
+    url: "https://github.com/PhilippvK/CMSIS_5.git"
+    ref: 21c549c7fdd4f92fb5a16e98212fb9b4df2ab672
+  mlif:
+    url: "https://github.com/tum-ei-eda/mlonmcu-sw.git"
+    ref: 99624237110838fb564f2e6fce838f1962744635
+  espidf:
+    url: "https://github.com/espressif/esp-idf.git"
+    ref: release/v4.4
+    options:
+      recursive: true
+  microtvm_etiss:
+    url: "https://github.com/PhilippvK/microtvm-etiss-template.git"
+    ref: 41e591ea5479484154598fa74e3d7097ded3da86
+  onnx2c:
+    url: "https://github.com/mischirmer/onnx2c.git"
+    ref: master
+    options:
+      recursive: true
+# Here all supported frameworks with their specific features are defined
+# Optionally disable unwanted or incomatible backends or features here
+# The configured defaults are used if no backend was specified in the command line options
+frameworks:
+  default: tflm
+  tflm:
+    enabled: true
+    backends:
+      default: tflmi
+      tflmc:
+        enabled: false
+      tflmi:
+        enabled: true
+        features:
+          debug_arena: true
+    features:
+      muriscvnn: false
+      cmsisnn: false
+  tvm:
+    enabled: true
+    backends:
+      default: tvmaot
+      tvmrt:
+        enabled: true
+        features:
+          debug_arena: true
+          disable_legalize: false
+          autotune: true
+          autotuned: true
+      tvmaot:
+        enabled: true
+        features:
+          debug_arena: true
+          unpacked_api: true
+          usmp: false
+          disable_legalize: false
+          autotune: true
+          autotuned: true
+      tvmllvm:
+        enabled: false
+        features:
+          # unpacked_api: true
+          disable_legalize: true
+          autotune: true
+          autotuned: true
+      tvmcg:
+        enabled: false
+        features:
+          debug_arena: true
+          disable_legalize: true
+          autotune: true
+          autotuned: true
+    features:
+      cmsisnnbyoc: false
+      muriscvnnbyoc: false
+  none:
+    enabled: true
+    backends:
+      default: onnx2c
+      none:
+        enabled: true
+      onnx2c:
+        enabled: true
+# Some frontends are experimental and therefore disabled here
+# Features like packing are only available in certain environments
+frontends:
+  tflite:
+    enabled: true
+    features:
+      validate: true
+      visualize: false
+  relay:
+    enabled: false
+    features:
+      relayviz: false
+  packed:
+    enabled: false
+    features:
+      packing: true
+      packed: true
+  onnx:
+    enabled: true
+  # TODO: saved_model (TF->TFLITE), ipynb (IPYNB->?)
+# Some targets/platforms support multiple toolchains
+toolchains:
+  gcc: true
+  llvm: true
+# Platform extend the number of supported targets
+platforms:
+  mlif:
+    enabled: true
+    features:
+      debug: true
+      validate: true
+      benchmark: true
+  espidf:
+    enabled: false
+    features:
+      debug: true
+  zephyr:
+    enabled: false
+    features:
+      debug: true
+  tvm:
+    enabled: true
+    features:
+      benchmark: true
+      tvm_rpc: true
+      autotune: true
+      tvm_profile: true
+  microtvm:
+    enabled: true
+    features: []
+      # validate: true
+# List of supported targets in the environment
+# List of supported targets in the environment
+targets:
+  default: host_x86
+  etiss_pulpino:
+    enabled: false
+    features:
+      gdbserver: true
+      etissdbg: true
+      trace: true
+      log_instrs: true
+      # vext: true
+      # pext: true
+  host_x86:
+    enabled: true
+    features:
+      gdbserver: true
+  spike:
+    enabled: false
+    features:
+      vext: false
+      pext: false
+      cachesim: true
+      log_instrs: true
+  ovpsim:
+    enabled: false
+    features:
+      vext: false
+      # pext: false
+  corstone300:
+    enabled: false
+    features:
+      ethosu: false
+      arm_mvei: false
+      arm_dsp: false
+  microtvm_etiss:
+    enabled: true
+  microtvm_espidf:
+    enabled: false
+postprocesses:
+  use:
+  # - detailed_cycles
+  # - average_cycles
+  # - filter_cols
+  # - features2cols
+  # - config2cols
+  # - bytes2kb
+  # - visualize
+# This is where further options such as specific versions of dependencies can be set in the furture
+vars:
+  allow_extensions: false
+  runs_per_stage: true
+  # tvm.make_tool: "ninja"
+  # llvm.distribution: x86_64-linux-gnu-ubuntu-18.04
+  # llvm.version: 18.1.8
+  llvm.dl_url: "https://github.com/PhilippvK/riscv-tools/releases/download/llvm_18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-{{ ubuntu_version if ubuntu_version is defined else '20.04'}}.tar.xz"
+  riscv_gcc_rv32.dl_url: "https://github.com/PhilippvK/riscv-tools/releases/download/gnu_2024.09.03_gcc14/riscv32-unknown-elf-ubuntu-{{ ubuntu_version if ubuntu_version is defined else '20.04'}}-rv32gc_ilp32d.tar.xz"
+  riscv_gcc_rv32.dl_url_vext: "https://github.com/PhilippvK/riscv-tools/releases/download/gnu_2024.09.03_gcc14/riscv32-unknown-elf-ubuntu-{{ ubuntu_version if ubuntu_version is defined else '20.04'}}-rv32gcv_ilp32d.tar.xz"
+  riscv_gcc_multilib.dl_url: "https://github.com/PhilippvK/riscv-tools/releases/download/gnu_2024.09.03_gcc14/riscv64-unknown-elf-ubuntu-{{ ubuntu_version if ubuntu_version is defined else '20.04'}}-multilib_default.tar.xz"
+flags:
+  tflmc.exe:
+  - x86

--- a/mlonmcu/setup/tasks/__init__.py
+++ b/mlonmcu/setup/tasks/__init__.py
@@ -52,5 +52,6 @@ from .corev import *  # noqa: F401, F403
 from .cv32e40p import *  # noqa: F401, F403
 from .boost import *  # noqa: F401, F403
 from .cmake import *  # noqa: F401, F403
+from .onnx2c import *  # noqa: F401, F403
 from .tgc import *  # noqa: F401, F403
 from .yosys import *  # noqa: F401, F403

--- a/mlonmcu/setup/tasks/onnx2c.py
+++ b/mlonmcu/setup/tasks/onnx2c.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2022 TUM Department of Electrical and Computer Engineering.
+#
+# This file is part of MLonMCU.
+# See https://github.com/tum-ei-eda/mlonmcu.git for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Definition of tasks used to dynamically install onnx2c dependencies."""
+
+import multiprocessing
+from pathlib import Path
+
+from mlonmcu.setup.task import TaskType
+from mlonmcu.context.context import MlonMcuContext
+from mlonmcu.setup import utils
+
+from .common import get_task_factory
+
+Tasks = get_task_factory()
+
+
+def _validate_onnx2c(context: MlonMcuContext, params=None):
+    del params
+    if not context.environment.has_backend("onnx2c"):
+        return False
+    return True
+
+
+@Tasks.provides(["onnx2c.src_dir"])
+@Tasks.validate(_validate_onnx2c)
+@Tasks.register(category=TaskType.BACKEND)
+def clone_onnx2c(
+    context: MlonMcuContext, params=None, rebuild=False, verbose=False, threads=multiprocessing.cpu_count()
+):
+    """Clone the onnx2c repository."""
+    del params, verbose, threads
+    onnx2c_name = utils.makeDirName("onnx2c")
+    onnx2c_src_dir = context.environment.paths["deps"].path / "src" / onnx2c_name
+    if rebuild or not utils.is_populated(onnx2c_src_dir):
+        if "onnx2c" not in context.environment.repos:
+            raise RuntimeError(
+                "Missing repository definition for 'onnx2c' in environment.yml (repos section)."
+            )
+        onnx2c_repo = context.environment.repos["onnx2c"]
+        utils.clone_wrapper(onnx2c_repo, onnx2c_src_dir, refresh=rebuild)
+    context.cache["onnx2c.src_dir"] = onnx2c_src_dir
+
+
+@Tasks.needs(["onnx2c.src_dir"])
+@Tasks.optional(["cmake.exe"])
+@Tasks.provides(["onnx2c.build_dir", "onnx2c.exe"])
+@Tasks.validate(_validate_onnx2c)
+@Tasks.register(category=TaskType.BACKEND)
+def build_onnx2c(context: MlonMcuContext, params=None, rebuild=False, verbose=False, threads=multiprocessing.cpu_count()):
+    """Build the onnx2c compiler executable."""
+    del params
+    user_vars = context.environment.vars
+    onnx2c_name = utils.makeDirName("onnx2c")
+    onnx2c_src_dir = None
+    if "onnx2c.src_dir" in user_vars:
+        onnx2c_src_dir = Path(user_vars["onnx2c.src_dir"])
+    else:
+        try:
+            onnx2c_src_dir = context.lookup("onnx2c.src_dir", ())
+        except KeyError:
+            src_base_dir = context.environment.paths["deps"].path / "src"
+            candidate = src_base_dir / onnx2c_name
+            if utils.is_populated(candidate):
+                onnx2c_src_dir = candidate
+    if onnx2c_src_dir is None:
+        raise RuntimeError(
+            "Unable to resolve onnx2c source directory. "
+            "Run 'mlonmcu setup --task clone_onnx2c --rebuild' first, or set 'onnx2c.src_dir' in vars."
+        )
+
+    onnx2c_build_dir = context.environment.paths["deps"].path / "build" / onnx2c_name
+    onnx2c_install_dir = context.environment.paths["deps"].path / "install" / onnx2c_name
+    onnx2c_exe = onnx2c_install_dir / "onnx2c"
+    cmake_exe = context.cache.get("cmake.exe")
+
+    if rebuild or not utils.is_populated(onnx2c_build_dir) or not onnx2c_exe.is_file():
+        utils.mkdirs(onnx2c_build_dir)
+        utils.cmake(
+            "-DCMAKE_BUILD_TYPE=Release",
+            str(onnx2c_src_dir),
+            cwd=onnx2c_build_dir,
+            live=verbose,
+            cmake_exe=cmake_exe,
+        )
+        utils.make(cwd=onnx2c_build_dir, threads=threads, live=verbose)
+        utils.mkdirs(onnx2c_install_dir)
+        utils.copy(onnx2c_build_dir / "onnx2c", onnx2c_exe)
+
+    context.cache["onnx2c.build_dir"] = onnx2c_build_dir
+    context.cache["onnx2c.exe"] = onnx2c_exe
+    context.export_paths.add(onnx2c_exe.parent)


### PR DESCRIPTION
Added a backend for using ONNX2C for code generation.

For quantized models: use [mischirmer:onnx2c:master](https://github.com/mischirmer/onnx2c) as some operators are still missing in upstream onnx2c.

Tested e.g. with converted MLPerf Tiny AWW example ([ONNX AWW](https://github.com/mischirmer/mlonmcu-models/tree/onnx_aww/onnx_aww), [ONNX AWW FP](https://github.com/mischirmer/mlonmcu-models/tree/onnx_aww/onnx_aww_fp))